### PR TITLE
Change id->transaction_id in events table and change primary key to c…

### DIFF
--- a/resources/migrations/20170605185629-change-event-id.down.sql
+++ b/resources/migrations/20170605185629-change-event-id.down.sql
@@ -1,0 +1,1 @@
+drop table events;

--- a/resources/migrations/20170605185629-change-event-id.up.sql
+++ b/resources/migrations/20170605185629-change-event-id.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE events RENAME id TO transaction_id;
+ALTER TABLE events ADD id BIGSERIAL;
+ALTER TABLE events DROP CONSTRAINT events_pkey;
+ALTER TABLE events ADD PRIMARY KEY(transaction_id, user_id, transaction_date);

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -22,8 +22,8 @@ WHERE id = :id
 -- :name create-event! :! :n
 -- :doc creates a new user record
 INSERT INTO events
-(id, user_id, transaction_date, amount, recipient, type)
-VALUES (:id, :user-id, :transaction-date, :amount, :recipient, :type)
+(transaction_id, user_id, transaction_date, amount, recipient, type)
+VALUES (:transaction-id, :user-id, :transaction-date, :amount, :recipient, :type)
 ON CONFLICT DO NOTHING
 
 -- :name get-events :? :*


### PR DESCRIPTION
…onsist of that, date and user id

- "Arkistointitunnus" in OP data, which was used for id, is reused for all occurrences of recurring expenses,
  so it was not good for primary key
- Also added autoincrementing id to events
- Fixes #4